### PR TITLE
Add perl.perlCmd support

### DIFF
--- a/lib/Perl/LanguageServer/Methods/workspace.pm
+++ b/lib/Perl/LanguageServer/Methods/workspace.pm
@@ -17,6 +17,13 @@ sub _rpcnot_didChangeConfiguration
 
     #print STDERR "perl = ", dump ($req -> params -> {settings}{perl}), "\n" ;
 
+    my $perlcmd = $req -> params -> {settings}{perl}{perlCmd} ;
+    if ($perlcmd) {
+        $workspace -> perlcmd ($perlcmd);
+    }
+
+    print STDERR "perlcmd = ", dump ( $workspace -> perlcmd), "\n" ;
+
     my $uri   = $req -> params -> {settings}{perl}{sshWorkspaceRoot} ;
     if ($uri)
         {


### PR DESCRIPTION
Add support for the perl.perlCmd setting. This can be useful to specify an alternative perl interpreter, or for example a wrapper script that sets environment variables before calling perl.