### PR TITLE
Makefile.PL: add META_MERGE with GitHub info

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,6 +37,16 @@ WriteMakefile(
     VERSION_FROM     => 'lib/Perl/LanguageServer.pm',
     ABSTRACT_FROM    => 'lib/Perl/LanguageServer.pm',
     LICENSE          => 'artistic_2',
+    META_MERGE       => {
+        'meta-spec'  => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url => 'https://github.com/richterger/Perl-LanguageServer.git',
+                web => 'https://github.com/richterger/Perl-LanguageServer',
+            },
+        },
+    },
     PL_FILES         => {},
     MIN_PERL_VERSION => '5.014',
     CONFIGURE_REQUIRES => {


### PR DESCRIPTION
See example at https://metacpan.org/pod/ExtUtils::MakeMaker#META_MERGE

This should allow the GitHub repository to appear in the sidebar of the module's page on MetaCPAN.