### PR TITLE
Prevent dereferencing an undefined value

### DIFF
--- a/lib/Perl/LanguageServer/Methods/workspace.pm
+++ b/lib/Perl/LanguageServer/Methods/workspace.pm
@@ -79,7 +79,7 @@ sub _rpcnot_didChangeConfiguration
 
     print STDERR "ignore_dir = ", dump ( $workspace -> ignore_dir), "\n" ;    
 
-    if (!exists ($workspace -> config -> {workspaceFolders}) || @{$workspace -> config -> {workspaceFolders}} == 0)
+    if (!exists ($workspace -> config -> {workspaceFolders}) || @{$workspace -> config -> {workspaceFolders} // []} == 0)
         {
         $workspace -> config -> {workspaceFolders} = [{ uri => $workspace -> config -> {rootUri} }] ;
         }


### PR DESCRIPTION
Tried to edit a lone Perl module outside a workspace environment in a freshly installed VSCode.
Running the LanguageServer led to the following error being reported in the VSCode output pane:
LS: ERROR: Can't use an undefined value as an ARRAY reference at /usr/lib/perl5/site_perl/5.30.1/Perl/LanguageServer/Methods/workspace.pm line 82.
Also reported as: https://rt.cpan.org/Public/Bug/Display.html?id=133349