### PR TITLE
Respect logging-related configuration settings

### DIFF
--- a/lib/Perl/LanguageServer.pm
+++ b/lib/Perl/LanguageServer.pm
@@ -501,20 +501,21 @@ sub run
     
     my $cv = AnyEvent::CondVar -> new ;
 
-   if ($heartbeat || $debug2)
+    async
         {
-        async
+        my $i = 0 ;
+        while (1)
             {
-            my $i = 0 ;
-            while (1)
+            if ($heartbeat || $debug2)
                 {
                 logger (undef, "##### $i #####\n running: " . dump (\%running_reqs) . " coros: " . dump (\%running_coros), "\n") ;
-                Coro::AnyEvent::sleep (10) ;
                 $i++ ;
                 }
-            } ;
-        }
-   
+
+            Coro::AnyEvent::sleep (10) ;
+            }
+        } ;
+
     if (!$no_stdio)
         {
         async

--- a/lib/Perl/LanguageServer/Methods/workspace.pm
+++ b/lib/Perl/LanguageServer/Methods/workspace.pm
@@ -15,7 +15,30 @@ sub _rpcnot_didChangeConfiguration
     {
     my ($self, $workspace, $req) = @_ ;
 
+    my $log_file   = $req -> params -> {settings}{perl}{logFile} ;
+    if ($log_file)
+        {
+        $Perl::LanguageServer::log_file = $log_file;
+        $self -> logger ("log_file = $log_file\n") ;
+        }
+
     $self -> logger ("perl = ", dump ($req -> params -> {settings}{perl}), "\n") ;
+
+    my $log_level   = $req -> params -> {settings}{perl}{logLevel} ;
+    if (defined $log_level && length $log_level)
+        {
+        my $int_log_level = 0+$log_level;
+        if ($int_log_level >= 0 && $int_log_level <= 2)
+            {
+            $Perl::LanguageServer::debug1 = $int_log_level;
+            $Perl::LanguageServer::debug2 = $int_log_level > 1?1:0;
+            $self -> logger ("log_level = $int_log_level\n") ;
+            }
+        else
+            {
+            $self -> logger ("log_level: unexpected value ($log_level)\n") ;
+            }
+        }
 
     my $uri   = $req -> params -> {settings}{perl}{sshWorkspaceRoot} ;
     if ($uri)


### PR DESCRIPTION
The extension readme (https://github.com/richterger/Perl-LanguageServer/blob/master/clients/vscode/perl/README.md) lists `perl.logFile` and `perl.logLevel` as supported settings, but the server doesn't currently respect those configuration settings (log file and log level can only be set by the `--log-file` and `--log-level` server command line arguments). This PR makes the server respect those logging-related configuration settings.