### PR TITLE
Spelling

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,7 +15,7 @@ Revision history for Perl-LanguageServer
           running threads which in turn caused the LanguageServer to hang
         - Prevent dereferencing an undefined value (#63) [Heiko Jansen]
         - Fix datatype of cwd config options (#47)
-        - Use perlInc setting also for LanguageServer itself (based ony pull request #54 from ALANVF)
+        - Use perlInc setting also for LanguageServer itself (based only pull request #54 from ALANVF)
         - Catch Exceptions during display of variables inside debugger
         - Fix detecting duplicate LanguageServer processes
 
@@ -27,12 +27,12 @@ Revision history for Perl-LanguageServer
         - search.cpan.org retired, replace with metacpan.org (#31) [Christopher Chavez]
 
 2.1.0   27.06.2020
-        - Improve Symbol Parser (fix parsing of anoymous subs)
+        - Improve Symbol Parser (fix parsing of anonymous subs)
         - showLocalSymbols
         - function names in breadcrump
         - Signature Help for function/method arguments
         - Add Presentation on Perl Workshop 2020 to repos
-        - Remove Complier::Lexer from distribution since 
+        - Remove Compiler::Lexer from distribution since 
           version is available on CPAN
         - Make stdout unbuffered while debugging
         - Make debugger use perlInc setting
@@ -66,7 +66,7 @@ Revision history for Perl-LanguageServer
           installation  
           
 0.03    08.09.2018
-        - Fix issue with not reading enougth from stdin, which
+        - Fix issue with not reading enough from stdin, which
           caused LanguageServer to hang sometimes
           
 0.02    21.07.2018

--- a/README
+++ b/README
@@ -14,7 +14,7 @@ with various editors/includes
 
 https://microsoft.github.io/debug-adapter-protocol/overview
 
-To use both with Visual Studio Code, install the extention "perl"
+To use both with Visual Studio Code, install the extension "perl"
 
 https://marketplace.visualstudio.com/items?itemName=richterger.perl
 
@@ -46,7 +46,7 @@ FEATURES
   * Tooltips with variable values
   * Evaluate perl code in debuggee, in context of every stack frame of coro thread
   * Automatically reload changed Perl modules while debugging
-  * Debug mutiple perl programm at once
+  * Debug multiple perl programm at once
   * Run on remote system via ssh
 
 INSTALLATION
@@ -61,7 +61,7 @@ To install this module, run the following commands:
 NOTE: Only tested with Perl 5.18 and newer. So in case you want to use
 is with older versions of Perl slight modifications might be necessary.
 
-To use it with Visual Studio Code, install the extention "perl"
+To use it with Visual Studio Code, install the extension "perl"
 
 
 SUPPORT AND DOCUMENTATION

--- a/clients/vscode/perl/CHANGELOG.md
+++ b/clients/vscode/perl/CHANGELOG.md
@@ -15,7 +15,7 @@
   running threads which in turn caused the LanguageServer to hang
 - Prevent dereferencing an undefined value (#63) [Heiko Jansen]
 - Fix datatype of cwd config options (#47)
-- Use perlInc setting also for LanguageServer itself (based ony pull request #54 from ALANVF)
+- Use perlInc setting also for LanguageServer itself (based only pull request #54 from ALANVF)
 - Catch Exceptions during display of variables inside debugger
 - Fix detecting duplicate LanguageServer processes
 
@@ -27,12 +27,12 @@
 - search.cpan.org retired, replace with metacpan.org (#31) [Christopher Chavez]
 
 ## 2.1.0    `2020-06-27`
-- Improve Symbol Parser (fix parsing of anoymous subs)
+- Improve Symbol Parser (fix parsing of anonymous subs)
 - showLocalSymbols
 - function names in breadcrump
 - Signature Help for function/method arguments
 - Add Presentation on Perl Workshop 2020 to repos
-- Remove Complier::Lexer from distribution since 
+- Remove Compiler::Lexer from distribution since 
     version is available on CPAN
 - Make stdout unbuffered while debugging
 - Make debugger use perlInc setting
@@ -57,10 +57,10 @@ Added Perl debugger
 Fix issues in the Perl part, make sure to update Perl::LanguageServer from cpan
 
 ## 0.0.3   `2018-09-08`
-Fix issue with not reading enougth from stdin, which caused LanguageServer to hang sometimes
+Fix issue with not reading enough from stdin, which caused LanguageServer to hang sometimes
 
 ## 0.0.2  `2018-07-21` 
-Fix quiting issue when starting Perl::LanguageServer, more fixes are in the Perl part
+Fix quitting issue when starting Perl::LanguageServer, more fixes are in the Perl part
 
 ## 0.0.1  `2018-07-13`
 Initial Version

--- a/clients/vscode/perl/README.md
+++ b/clients/vscode/perl/README.md
@@ -52,7 +52,7 @@ This extension contributes the following settings:
 * `perl.perlArgs`: additional arguments passed to the perl interpreter that starts the LanguageServer
 * `perl.sshArgs`: optional arguments for ssh
 * `perl.pathMap`: mapping of local to remote paths
-* `perl.perlInc`: array with paths to add to perl library path. This setting is used by the syntax checker and for the debugee and also for the LanguageServer itself.
+* `perl.perlInc`: array with paths to add to perl library path. This setting is used by the syntax checker and for the debuggee and also for the LanguageServer itself.
 * `perl.fileFilter`: array for filtering perl file, defaults to [*.pm,*.pl]
 * `perl.ignoreDirs`: directories to ignore, defaults to [.vscode, .git, .svn]
 * `perl.debugAdapterPort`: port to use for connection between vscode and debug adapter inside Perl::LanguageServer. On a multi user system every user must use a different port.
@@ -70,7 +70,7 @@ This extension contributes the following settings:
 * `stopOnEntry`: if true, program will stop on entry
 * `args`:   optional, array with arguments for perl program
 * `env`:    optional, object with environment settings 
-* `cwd`:    optional, change working directory before launching the debugee
+* `cwd`:    optional, change working directory before launching the debuggee
 * `reloadModules`: if true, automatically reload changed Perl modules while debugging
 
 ## Remote syntax check & debugging

--- a/clients/vscode/perl/package.json
+++ b/clients/vscode/perl/package.json
@@ -82,7 +82,7 @@
                 "perl.perlInc": {
                     "type": "array",
                     "default": null,
-                    "description": "array with paths to add to perl library path. This setting is used by the syntax checker and for the debugee and also for the LanguageServer itself."
+                    "description": "array with paths to add to perl library path. This setting is used by the syntax checker and for the debuggee and also for the LanguageServer itself."
                 },
                 "perl.fileFilter": {
                     "type": "array",
@@ -153,7 +153,7 @@
                             },
                             "cwd": {
                                 "type": "string",
-                                "description": "optional, change working directory before launching the debugee.",
+                                "description": "optional, change working directory before launching the debuggee.",
                                 "default": null
                             },
                             "reloadModules": {

--- a/lib/Perl/LanguageServer.pm
+++ b/lib/Perl/LanguageServer.pm
@@ -51,7 +51,7 @@ with various editors/includes
 
 L<https://microsoft.github.io/debug-adapter-protocol/overview>
 
-To use both with Visual Studio Code, install the extention "perl"
+To use both with Visual Studio Code, install the extension "perl"
 
 Any comments and patches are welcome.
 
@@ -219,7 +219,7 @@ sub call_method
         $perlmethod = (defined($id)?'_rpcreq_':'_rpcnot_') . $name ;
         }
     $self -> logger ("method=$perlmethod\n") if ($debug1) ;
-    die "Unknow perlmethod $perlmethod" if (!$self -> can ($perlmethod)) ;
+    die "Unknown perlmethod $perlmethod" if (!$self -> can ($perlmethod)) ;
 
 no strict ;
     return $self -> $perlmethod ($workspace, $req) ;

--- a/lib/Perl/LanguageServer/DebuggerInterface.pm
+++ b/lib/Perl/LanguageServer/DebuggerInterface.pm
@@ -1588,7 +1588,7 @@ sub _recv
         $class -> _send ({ command => 'di_response', seq => $cmddata -> {seq}, arguments => $result}) ;
         return ;
         }
-    die "unknow cmd $cmd" ;    
+    die "unknown cmd $cmd" ;    
     }
 
 

--- a/lib/Perl/LanguageServer/DebuggerProcess.pm
+++ b/lib/Perl/LanguageServer/DebuggerProcess.pm
@@ -116,7 +116,7 @@ sub send_event
 
 # ---------------------------------------------------------------------------
 
-sub lauch
+sub launch
     {
     my ($self, $workspace, $cmd) = @_ ;
 

--- a/lib/Perl/LanguageServer/Methods/DebugAdapter.pm
+++ b/lib/Perl/LanguageServer/Methods/DebugAdapter.pm
@@ -419,7 +419,7 @@ sub _dapreq_launch
     $self -> debugger_process ($proc) ;
     $proc -> debug_adapter ($self) ;
     $debug_adapters{$proc -> session_id} = $self ;
-    $proc -> lauch ($workspace, $workspace -> perlcmd) ;
+    $proc -> launch ($workspace, $workspace -> perlcmd) ;
 
     return {} ;
     }

--- a/lib/Perl/LanguageServer/Methods/textDocument.pm
+++ b/lib/Perl/LanguageServer/Methods/textDocument.pm
@@ -197,7 +197,7 @@ sub _filter_children
     my @vars ;
     foreach my $v (@$children)
         {
-        if (exists $v -> {defintion} && (!exists $v -> {localvar} || $show_local_vars))
+        if (exists $v -> {definition} && (!exists $v -> {localvar} || $show_local_vars))
             {
             if (exists $v -> {children})
                 {
@@ -234,7 +234,7 @@ sub _rpcreq_documentSymbol
     my @vars ;
     foreach my $v (@$vars)
         {
-        if (exists $v -> {defintion} && (!exists $v -> {localvar} || $show_local_vars))
+        if (exists $v -> {definition} && (!exists $v -> {localvar} || $show_local_vars))
             {
             if (exists $v -> {children})
                 {
@@ -267,7 +267,7 @@ sub _get_symbol
 
     return if ($symbol -> {name} ne $name) ;
     #print STDERR "name=$name symbols = ", pp ($symbol), "\n" ;
-    return if ($def_only && !exists $symbol -> {defintion}) ;
+    return if ($def_only && !exists $symbol -> {definition}) ;
     my $line = $symbol -> {line} + 0 ;
     push @$vars, { uri => $uri, range => { start => { line => $line, character => 0 }, end => { line => $line, character => 0 }}} ;
     }
@@ -351,7 +351,7 @@ sub _rpcreq_signatureHelp
         foreach my $symbol (@{$symbols->{$uri}})
             {
             next if ($symbol -> {name} ne $name) ;
-            next if (!exists $symbol -> {defintion}) ;
+            next if (!exists $symbol -> {definition}) ;
             next if (!exists $symbol -> {signature}) ;
 
             push @vars, $symbol -> {signature} ;

--- a/lib/Perl/LanguageServer/Methods/workspace.pm
+++ b/lib/Perl/LanguageServer/Methods/workspace.pm
@@ -142,7 +142,7 @@ sub _rpcreq_symbol
         foreach my $symbol (@{$symbols->{$uri}})
             {
             next if ($symbol -> {name} !~ /$query/) ;
-            next if (!exists $symbol -> {defintion}) ;
+            next if (!exists $symbol -> {definition}) ;
             $line = $symbol -> {line} ;
             push @vars, { %$symbol, location => { uri => $uri, range => { start => { line => $line, character => 0 }, end => { line => $line, character => 0 }}} } ;
             last if (@vars > 200) ;

--- a/lib/Perl/LanguageServer/Parser.pm
+++ b/lib/Perl/LanguageServer/Parser.pm
@@ -148,7 +148,7 @@ sub parse_perl_source
                     name        => $token -> {data},
                     kind        => SymbolKindVariable,
                     containerName => $decl eq 'our'?$package:$func,     
-                    ($decl?(defintion   => $decl):()),
+                    ($decl?(definition   => $decl):()),
                     ($decl eq 'my'?(localvar => $decl):()),
                     } ; 
                 $add = $top -> [-1] ;
@@ -200,7 +200,7 @@ sub parse_perl_source
                         name        => $token -> {data},
                         kind        => SymbolKindFunction,
                         containerName => @stack?$func:$package,     
-                        ($decl?(defintion   => $decl):()),
+                        ($decl?(definition   => $decl):()),
                         }  ;  
                     $func_param = $add = $top -> [-1] ;
                     if ($decl)
@@ -304,7 +304,7 @@ sub parse_perl_source
                         name        => $token -> {data},
                         kind        => SymbolKindConstant,
                         containerName => $package,     
-                        defintion   => 1,
+                        definition   => 1,
                         } ;    
                     $add = $top -> [-1] ;
                     }
@@ -350,7 +350,7 @@ sub parse_perl_source
                         name        => $token -> {data},
                         kind        => SymbolKindProperty,
                         containerName => $package,     
-                        defintion   => 1,
+                        definition   => 1,
                         } ;
                     $add = $top -> [-1] ;
                     }
@@ -398,8 +398,8 @@ sub parse_perl_source
                                 name        => $package,
                                 kind        => SymbolKindModule,
                                 #containerName => join ('::', @{$state{ns}}),
-                                #($def?(defintion   => $def):()),
-                                defintion => 1,
+                                #($def?(definition   => $def):()),
+                                definition => 1,
                                 } ;   
                             $add = $top -> [-1] ;
                             }
@@ -412,7 +412,7 @@ sub parse_perl_source
                                 name        => $name,
                                 kind        => SymbolKindModule,
                                 containerName => join ('::', @{$state{ns}}),
-                                ($def?(defintion   => $def):()),
+                                ($def?(definition   => $def):()),
                                 } ;   
                             $add = $top -> [-1] ;
                             }


### PR DESCRIPTION
I have divided the PR into three parts:

1. General spelling fixes.
2. A method `lauch`, likely `launch` is renamed.
3. The changelogs are checked also.