### PR TITLE
Perl::Tidy is needed for the Vscode extension

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -68,6 +68,7 @@ WriteMakefile(
         'Class::Refresh'     => '0',
         'Compiler::Lexer'    => '0.23',
         'Hash::SafeKeys'     => '0',
+        'Perl::Tidy'         => '0'
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Perl-LanguageServer-*' },


### PR DESCRIPTION
When PLS is used as the debugger in VSCODE and Perl::Tidy isn not installed, saving a file will format it to a blank file.
The formatter is enabled by default in VSCODE so I believe Perl::Tidy should be a dependency of PLS.
