### PR TITLE
Issue#91 "No DB::DB routine defined". Change to work on perl 5.16.3 o…

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use v5.18;
+use v5.16;
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;

--- a/README.pod
+++ b/README.pod
@@ -96,6 +96,15 @@ e.g. on Debian/Ubuntu run:
      
      sudo cpan Perl::LanguageServer
     
+e.g. on Centos 7 run:
+
+
+    
+     sudo yum install perl-App-cpanminus perl-AnyEvent-AIO perl-Coro
+     sudo cpanm Class::Refresh
+     sudo cpanm Compiler::Lexer
+     sudo cpanm Hash::SafeKeys
+     sudo cpanm Perl::LanguageServer
 
 In case any of the above packages are not available for your os version, just
 leave then out. The cpan command will install missing dependencies. In case

--- a/lib/Perl/LanguageServer.pm
+++ b/lib/Perl/LanguageServer.pm
@@ -1,6 +1,6 @@
 package Perl::LanguageServer;
 
-use v5.18;
+use v5.16;
 
 use strict ;
 use Moose ;

--- a/lib/Perl/LanguageServer/DebuggerProcess.pm
+++ b/lib/Perl/LanguageServer/DebuggerProcess.pm
@@ -143,7 +143,7 @@ sub launch
     
     $ENV{PLSDI_REMOTE} = '127.0.0.1:' . $self -> debug_adapter -> listen_port ;
     $ENV{PLSDI_OPTIONS} = $self -> reload_modules?'reload_modules':'' ;
-    $ENV{PERL5DB}      = 'BEGIN { $| = 1 ; ' . $cwd . 'require Perl::LanguageServer::DebuggerInterface }' ;
+    $ENV{PERL5DB}      = 'BEGIN { $| = 1 ; ' . $cwd . 'require Perl::LanguageServer::DebuggerInterface; DB::DB(); }' ;
     $ENV{PLSDI_SESSION}= $self -> session_id ;
     $pid = $self -> run_async ([$cmd, @inc, '-d', $fn, @{$self -> args}]) ;
     }

--- a/lib/Perl/LanguageServer/Parser.pm
+++ b/lib/Perl/LanguageServer/Parser.pm
@@ -7,11 +7,11 @@ use Coro::AIO ;
 use JSON ;
 use File::Basename ;
 
-use v5.18;
+use v5.16;
 
-no warnings 'experimental' ;
+no if $] >= 5.018, warnings => 'experimental'; # given, when, Smartmatch
 no warnings 'uninitialized' ;
-
+use feature 'switch'; # perl 5.16
 
 use Compiler::Lexer;
 use Data::Dump qw{dump} ;


### PR DESCRIPTION
…n Centos/RHEL 7 and document installation. This code might work on earlier perls from 5.12 on.

I re-applied the changes after turning off the tab-to-whitespace in my editor so it is just code changes now.
