### PR TITLE
update call to gensym(), to fix 'strict subs' error

### DIFF
--- a/lib/Perl/LanguageServer/IO.pm
+++ b/lib/Perl/LanguageServer/IO.pm
@@ -96,7 +96,7 @@ sub _write
 
     require IPC::Open3 ;
     require Symbol ; 
-    $err = Symbol::gensym ;
+    $err = Symbol::gensym () ;
     my $pid = IPC::Open3::open3($wtr, $rdr, $err, @$cmd) or die "Cannot run @$cmd" ;
 
     $self -> out_fh ($wtr) ;


### PR DESCRIPTION
In Debian we are currently applying the following patch to
Perl-LanguageServer.
We thought you might be interested in it too.

Description: update call to gensym(), to fix 'strict subs' error Origin: vendor
Author: mason james <mtj@kohaaloha.com>
Last-Update: 2023-01-23

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libperl-languageserver-perl/raw/master/debian/patches/gensym.patch

Thanks for considering,
mason james,
Debian Perl Group