### PR TITLE
enable utf8 on stdout and stderr

### DIFF
--- a/lib/Perl/LanguageServer/DebuggerProcess.pm
+++ b/lib/Perl/LanguageServer/DebuggerProcess.pm
@@ -4,7 +4,8 @@ use 5.006;
 use strict;
 use Moose ;
 
-use utf8;
+use Encode::Locale;
+use Encode;
 use File::Basename ;
 use Coro ;
 use Coro::AIO ;
@@ -182,7 +183,7 @@ sub on_stdout
 
     foreach my $line (split /\r?\n/, $data)
         {
-        utf8::decode($line);
+        $line = decode(locale => $line);
         $self -> send_event ('output', { category => 'stdout', output => $line . "\r\n" }) ;
         }
     }
@@ -195,7 +196,7 @@ sub on_stderr
 
     foreach my $line (split /\r?\n/, $data)
         {
-        utf8::decode($line);
+        $line = decode(locale => $line);
         $self -> send_event ('output', { category => 'stderr', output => $line . "\r\n" }) ;
         }
     }

--- a/lib/Perl/LanguageServer/DebuggerProcess.pm
+++ b/lib/Perl/LanguageServer/DebuggerProcess.pm
@@ -4,6 +4,7 @@ use 5.006;
 use strict;
 use Moose ;
 
+use utf8;
 use File::Basename ;
 use Coro ;
 use Coro::AIO ;
@@ -181,6 +182,7 @@ sub on_stdout
 
     foreach my $line (split /\r?\n/, $data)
         {
+        utf8::decode($line);
         $self -> send_event ('output', { category => 'stdout', output => $line . "\r\n" }) ;
         }
     }
@@ -193,6 +195,7 @@ sub on_stderr
 
     foreach my $line (split /\r?\n/, $data)
         {
+        utf8::decode($line);
         $self -> send_event ('output', { category => 'stderr', output => $line . "\r\n" }) ;
         }
     }


### PR DESCRIPTION
Data is always utf8 on stdout and stderr.