### PR TITLE
fix spelling

### DIFF
--- a/Changes.pod
+++ b/Changes.pod
@@ -6,9 +6,9 @@
 
 =item * Set minimal Perl version to 5.16 (#91)
 
-=item * Per default enviroment from vscode will be passed to debuggee, syntax check and perltidy.
+=item * Per default environment from vscode will be passed to debuggee, syntax check and perltidy.
 
-=item * Add configuration C<disablePassEnv> to not pass enviroment variables.
+=item * Add configuration C<disablePassEnv> to not pass environment variables.
 
 =item * Support for C<logLevel> and C<logFile> settings via LanguageServer protocol and
 not only via command line options (#97) [schellj]
@@ -29,7 +29,7 @@ not only via command line options (#97) [schellj]
 
 =item * Choose a different port for debugAdapterPort if it is already in use. This
 avoids trouble with starting C<Perl::LanguageServer> if another instance
-of C<Perl::LanguageServer> is runing on the same machine (thanks to hakonhagland)
+of C<Perl::LanguageServer> is running on the same machine (thanks to hakonhagland)
 
 =item * Add configuration C<debugAdapterPortRange>, for choosing range of port for dynamic
 port assignment
@@ -86,7 +86,7 @@ so watchs and code from the debug console is not expanded properly
 =item * Fix: sshArgs parameter was not declared as array (#109)
 
 =item * Disable syntax check on windows, because it blocks the whole process when running on windows,
-until handling of childs processes is fixed
+until handling of child's processes is fixed
 
 =item * Fixed spelling (#86,#96,#101) [chrstphrchvz,davorg,aluaces]
 

--- a/README.pod
+++ b/README.pod
@@ -279,7 +279,7 @@ Change port setting from string to integer
 Please make sure the path to the module is in C<perl.perlInc> setting and use absolute path names in the perlInc settings
 or make sure you are running in the expected directory by setting the C<cwd> setting in the lauch.json.
 
-=head3 ERROR: Unknow perlmethod I<rpcnot>setTraceNotification
+=head3 ERROR: Unknown perlmethod I<rpcnot>setTraceNotification
 
 This is not an issue, that just means that not all features of the debugging protocol are implemented.
 Also it says ERROR, it's just a warning and you can safely ignore it.

--- a/lib/Perl/LanguageServer.pm
+++ b/lib/Perl/LanguageServer.pm
@@ -897,7 +897,7 @@ Change port setting from string to integer
 Please make sure the path to the module is in C<perl.perlInc> setting and use absolute path names in the perlInc settings
 or make sure you are running in the expected directory by setting the C<cwd> setting in the lauch.json.
 
-=head3 ERROR: Unknow perlmethod I<rpcnot>setTraceNotification
+=head3 ERROR: Unknown perlmethod I<rpcnot>setTraceNotification
 
 This is not an issue, that just means that not all features of the debugging protocol are implemented.
 Also it says ERROR, it's just a warning and you can safely ignore it.
@@ -1030,9 +1030,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 =item * Set minimal Perl version to 5.16 (#91)
 
-=item * Per default enviroment from vscode will be passed to debuggee, syntax check and perltidy.
+=item * Per default environment from vscode will be passed to debuggee, syntax check and perltidy.
 
-=item * Add configuration C<disablePassEnv> to not pass enviroment variables.
+=item * Add configuration C<disablePassEnv> to not pass environment variables.
 
 =item * Support for C<logLevel> and C<logFile> settings via LanguageServer protocol and
 not only via command line options (#97) [schellj]
@@ -1053,7 +1053,7 @@ not only via command line options (#97) [schellj]
 
 =item * Choose a different port for debugAdapterPort if it is already in use. This
 avoids trouble with starting C<Perl::LanguageServer> if another instance
-of C<Perl::LanguageServer> is runing on the same machine (thanks to hakonhagland)
+of C<Perl::LanguageServer> is running on the same machine (thanks to hakonhagland)
 
 =item * Add configuration C<debugAdapterPortRange>, for choosing range of port for dynamic
 port assignment
@@ -1110,7 +1110,7 @@ so watchs and code from the debug console is not expanded properly
 =item * Fix: sshArgs parameter was not declared as array (#109)
 
 =item * Disable syntax check on windows, because it blocks the whole process when running on windows,
-until handling of childs processes is fixed
+until handling of child's processes is fixed
 
 =item * Fixed spelling (#86,#96,#101) [chrstphrchvz,davorg,aluaces]
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Perl-LanguageServer.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libperl-languageserver-perl/raw/master/./debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
