### PR TITLE
use taint on syntax check

### DIFF
--- a/Changes.pod
+++ b/Changes.pod
@@ -1,5 +1,7 @@
 =head1 Change Log
 
+=item * When C<useTaintForSyntaxCheck> is true, use taint mode for syntax check.
+
 =head2 2.5.0   C<2023-02-05>
 
 =over

--- a/README.pod
+++ b/README.pod
@@ -180,6 +180,8 @@ This extension contributes the following settings:
 
 =item * C<stopOnEntry>: if true, program will stop on entry
 
+=item * C<useTaintForSyntaxCheck>: if true, use taint mode for syntax check.
+
 =item * C<args>:   optional, array with arguments for perl program
 
 =item * C<env>:    optional, object with environment settings

--- a/clients/vscode/perl/package.json
+++ b/clients/vscode/perl/package.json
@@ -114,6 +114,11 @@
                     "default": null,
                     "description": "array with paths to add to perl library path. This setting is used by the syntax checker and for the debuggee and also for the LanguageServer itself. perl.perlInc should be absolute paths."
                 },
+                "perl.useTaintForSyntaxCheck": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use -T for syntax check."
+                },
                 "perl.fileFilter": {
                     "type": "array",
                     "default": null,

--- a/lib/Perl/LanguageServer/DebuggerProcess.pm
+++ b/lib/Perl/LanguageServer/DebuggerProcess.pm
@@ -49,12 +49,6 @@ has 'stop_on_entry' =>
     is  => 'ro'
     ) ;
 
-has 'use_taint_for_syntax_check' =>
-    (
-    isa => 'Bool',
-    is  => 'ro'
-    ) ;
-
 has 'reload_modules' =>
     (
     isa => 'Bool',

--- a/lib/Perl/LanguageServer/DebuggerProcess.pm
+++ b/lib/Perl/LanguageServer/DebuggerProcess.pm
@@ -49,6 +49,12 @@ has 'stop_on_entry' =>
     is  => 'ro'
     ) ;
 
+has 'use_taint_for_syntax_check' =>
+    (
+    isa => 'Bool',
+    is  => 'ro'
+    ) ;
+
 has 'reload_modules' =>
     (
     isa => 'Bool',

--- a/lib/Perl/LanguageServer/Methods/workspace.pm
+++ b/lib/Perl/LanguageServer/Methods/workspace.pm
@@ -76,6 +76,9 @@ sub _rpcnot_didChangeConfiguration
 
     $self -> logger ("perlinc = ", dump ( $workspace -> perlinc), "\n") ;
 
+    $workspace -> use_taint_for_syntax_check ($req -> params -> {settings}{perl}{useTaintForSyntaxCheck}) ;
+    $self -> logger ("use_taint_for_syntax_check = ", dump ( $workspace -> use_taint_for_syntax_check), "\n") ;
+
     my $filter   = $req -> params -> {settings}{perl}{fileFilter} ;
     if ($filter)
         {

--- a/lib/Perl/LanguageServer/SyntaxChecker.pm
+++ b/lib/Perl/LanguageServer/SyntaxChecker.pm
@@ -245,7 +245,6 @@ sub background_checker
             }
         else
             {
-            # using -T to avoid problems with taint in hashbang line
             $ret = run_cmd ([$self -> perlcmd, $syntax_options, '-c', @inc],
                 "<", \$text,
                 ">", \$out,

--- a/lib/Perl/LanguageServer/SyntaxChecker.pm
+++ b/lib/Perl/LanguageServer/SyntaxChecker.pm
@@ -240,7 +240,7 @@ sub background_checker
             }
         else
             {
-            $ret = run_cmd ([$self -> perlcmd, '-c', @inc],
+            $ret = run_cmd ([$self -> perlcmd, '-T', '-c', @inc],
                 "<", \$text,
                 ">", \$out,
                 "2>", \$errout)

--- a/lib/Perl/LanguageServer/SyntaxChecker.pm
+++ b/lib/Perl/LanguageServer/SyntaxChecker.pm
@@ -232,7 +232,12 @@ sub background_checker
         my @inc ;
         @inc = map { ('-I', $_)} @$inc if ($inc) ;
 
-        $self -> logger ("start perl -T -c for $uri\n") if ($Perl::LanguageServer::debug1) ;
+        my $syntax_options = "";
+        if ($self -> use_taint_for_syntax_check) {
+            $syntax_options = "-T";
+        }
+
+        $self -> logger ("start perl $syntax_options -c for $uri\n") if ($Perl::LanguageServer::debug1) ;
         if ($^O =~ /Win/)
             {
 #            ($ret, $out, $errout) = $self -> run_open3 ($text, \@inc) ;
@@ -241,7 +246,7 @@ sub background_checker
         else
             {
             # using -T to avoid problems with taint in hashbang line
-            $ret = run_cmd ([$self -> perlcmd, '-T', '-c', @inc],
+            $ret = run_cmd ([$self -> perlcmd, $syntax_options, '-c', @inc],
                 "<", \$text,
                 ">", \$out,
                 "2>", \$errout)
@@ -249,7 +254,7 @@ sub background_checker
             }
 
         my $rc = $ret >> 8 ;
-        $self -> logger ("perl -T -c rc=$rc out=$out errout=$errout\n") if ($Perl::LanguageServer::debug1) ;
+        $self -> logger ("perl $syntax_options -c rc=$rc out=$out errout=$errout\n") if ($Perl::LanguageServer::debug1) ;
 
         my @messages ;
         if ($rc != 0)

--- a/lib/Perl/LanguageServer/SyntaxChecker.pm
+++ b/lib/Perl/LanguageServer/SyntaxChecker.pm
@@ -232,7 +232,7 @@ sub background_checker
         my @inc ;
         @inc = map { ('-I', $_)} @$inc if ($inc) ;
 
-        $self -> logger ("start perl -c for $uri\n") if ($Perl::LanguageServer::debug1) ;
+        $self -> logger ("start perl -T -c for $uri\n") if ($Perl::LanguageServer::debug1) ;
         if ($^O =~ /Win/)
             {
 #            ($ret, $out, $errout) = $self -> run_open3 ($text, \@inc) ;
@@ -240,6 +240,7 @@ sub background_checker
             }
         else
             {
+            # using -T to avoid problems with taint in hashbang line
             $ret = run_cmd ([$self -> perlcmd, '-T', '-c', @inc],
                 "<", \$text,
                 ">", \$out,
@@ -248,7 +249,7 @@ sub background_checker
             }
 
         my $rc = $ret >> 8 ;
-        $self -> logger ("perl -c rc=$rc out=$out errout=$errout\n") if ($Perl::LanguageServer::debug1) ;
+        $self -> logger ("perl -T -c rc=$rc out=$out errout=$errout\n") if ($Perl::LanguageServer::debug1) ;
 
         my @messages ;
         if ($rc != 0)

--- a/lib/Perl/LanguageServer/Workspace.pm
+++ b/lib/Perl/LanguageServer/Workspace.pm
@@ -83,6 +83,12 @@ has 'perlinc' =>
     is  => 'rw',
     ) ;
 
+has 'use_taint_for_syntax_check' =>
+    (
+    isa => 'Maybe[Bool]',
+    is  => 'rw'
+    ) ;
+
 has 'show_local_vars' =>
     (
     isa => 'Maybe[Bool]',


### PR DESCRIPTION
Like described in issue https://github.com/richterger/Perl-LanguageServer/issues/143
Using taint check for syntax check to prevent error message 
when first line is like "#!/usr/bin/perl -T" or "#!/usr/bin/perl -t"