### PR TITLE
Fix diagnostic notifications override on clients

### DIFF
--- a/lib/Perl/LanguageServer/Workspace.pm
+++ b/lib/Perl/LanguageServer/Workspace.pm
@@ -347,6 +347,8 @@ sub add_diagnostic_messages
         foreach my $filename (keys %diags)
             {
             my $fnuri = !$filename || $filename eq '-'?$uri:$self -> uri_server2client ('file://' . $filename) ;
+            $filename = $uri =~ s/file:\/\///r;
+
             my $result =
                 {
                 method => 'textDocument/publishDiagnostics',

--- a/lib/Perl/LanguageServer/Workspace.pm
+++ b/lib/Perl/LanguageServer/Workspace.pm
@@ -344,23 +344,20 @@ sub add_diagnostic_messages
 
     foreach my $filename (keys %diags)
         {
-        foreach my $filename (keys %diags)
+        my $fnuri = !$filename || $filename eq '-'?$uri:$self -> uri_server2client ('file://' . $filename) ;
+        $filename = $uri =~ s/file:\/\///r;
+
+        my $result =
             {
-            my $fnuri = !$filename || $filename eq '-'?$uri:$self -> uri_server2client ('file://' . $filename) ;
-            $filename = $uri =~ s/file:\/\///r;
-
-            my $result =
+            method => 'textDocument/publishDiagnostics',
+            params =>
                 {
-                method => 'textDocument/publishDiagnostics',
-                params =>
-                    {
-                    uri => $fnuri,
-                    diagnostics => $diags{$filename},
-                    },
-                } ;
+                uri => $fnuri,
+                diagnostics => $diags{$filename},
+                },
+            } ;
 
-            $server -> send_notification ($result) ;
-            }
+        $server -> send_notification ($result) ;
         }
     }
 


### PR DESCRIPTION
This PR fixes the diagnostic notifications getting overridden on clients due to multiple notifications for the same file with different diagnostic results and also notifications being sent twice for each file due to a erroneous nested loop.

Fixes #184