### PR TITLE
add a fallback for providing the source of a file not loaded in the debugger bridge

### DIFF
--- a/lib/Perl/LanguageServer/DebuggerInterface.pm
+++ b/lib/Perl/LanguageServer/DebuggerInterface.pm
@@ -1494,7 +1494,7 @@ sub req_source
     my ($class, $params) = @_ ;
 
     my $filename    = $params -> {filename} ;
-    my $source = join("", @{$main::{'_<'.$filename}});
+    my $source = join("", @{$main::{'_<'.$filename} // ["... source not found: $filename ..."]});
     $source =~ s/\n;$//;
 	  
     return { content => $source };


### PR DESCRIPTION
For context: I am running VS Code on windows, and debugging code that is running within Cygwin Perl, which causes some interesting complications.

The original code always assumes it can load the source for the given file, but occasionally it cannot, for reasons i have not yet further inspected. In those cases, the given code simply crashes, which is unfortunate as it usually is in a state where debugging should continue.

The provided patch simply catches this, inserts a message about the missing code, with what exactly is missing, and continues.

This, at the very least, is a useful fix for allowing further work.

For source cause analysis purposes, it seems in my particular case the missing file was:

`(eval 138)[c:/cygwin/home/Mithaldu/perl5/lib/perl5/Devel/GlobalDestruction.pm:16]`